### PR TITLE
Updated Categories Pages / Functionality

### DIFF
--- a/code-cast-project/app/(browse)/(home)/page.js
+++ b/code-cast-project/app/(browse)/(home)/page.js
@@ -34,7 +34,7 @@ const Home = () => {
   ];
 
   return (
-<div className="container mx-auto px-4 py-8" style={{ backgroundColor: '#0D1520' }}>
+<div className="flex flex-col min-h-screen w-full px-4 py-8" style={{ backgroundColor: '#0D1520' }}>
       <header className="flex justify-between items-center mb-8">
         <UserButton /><UserButton></UserButton>
       </header>

--- a/code-cast-project/app/(browse)/_components/container.js
+++ b/code-cast-project/app/(browse)/_components/container.js
@@ -16,7 +16,7 @@ function Container({ children }) {
     }
   }, [isMobile, onCollapse, onExpand]);
 
-  const marginLeftClass = collapsed ? 'ml-[70px]' : 'ml-[70px] lg:ml-60';
+  const marginLeftClass = collapsed ? 'ml-[70px]' : 'ml-[70px] lg:ml-[280px]';
 
   return <div className={`flex-1 ${marginLeftClass}`}>{children}</div>;
 }

--- a/code-cast-project/app/(browse)/categories/c-plus-plus/page.js
+++ b/code-cast-project/app/(browse)/categories/c-plus-plus/page.js
@@ -1,7 +1,38 @@
+"use client"
+
+import { useState, useEffect } from 'react';
+
 export default function CPlusPlusPage() {
+    const [streams, setStreams] = useState([]);
+
+    const categoryName = "C++";
+    const encodedCategoryName = encodeURIComponent(categoryName);
+
+    useEffect(() => {
+        async function fetchStreams() {
+            const response = await fetch(`/api/fetchStreams?categoryName=${encodedCategoryName}`);
+            const data = await response.json();
+            setStreams(data);
+        }
+
+        fetchStreams();
+    }, []);
+
     return (
         <div>
-            C++ Page!
+            <h1 className="text-2xl font-semibold lg:text-4xl">C++ Streams</h1>
+            {streams.length > 0 ? (
+                streams.map((stream) => (
+                    <div key={stream.id}>
+                        <Link href={`/${stream.user.username}`}>
+                            <h2>{stream.name}</h2>
+                        </Link>
+                        {/* Display other stream details here */}
+                    </div>
+                ))
+            ) : (
+                <p>No current streams under the C++ category.</p>
+            )}
         </div>
-    )
+    );
 }

--- a/code-cast-project/app/(browse)/categories/java/page.js
+++ b/code-cast-project/app/(browse)/categories/java/page.js
@@ -1,7 +1,36 @@
+"use client"
+
+import { useState, useEffect } from 'react';
+
 export default function JavaPage() {
+    const [streams, setStreams] = useState([]);
+
+    useEffect(() => {
+        async function fetchStreams() {
+            const response = await fetch('/api/fetchStreams?categoryName=Java');
+            const data = await response.json();
+            console.log(data);
+            setStreams(data);
+        }
+
+        fetchStreams();
+    }, []);
+
     return (
         <div>
-            Java Page!
+            <h1 className="text-2xl font-semibold lg:text-4xl">Java Streams</h1>
+            {streams.length > 0 ? (
+                streams.map((stream) => (
+                    <div key={stream.id}>
+                        <Link href={`/${stream.user.username}`}>
+                            <h2>{stream.name}</h2>
+                        </Link>
+                        {/* Display other stream details here */}
+                    </div>
+                ))
+            ) : (
+                <p>No current streams under the Java category.</p>
+            )}
         </div>
-    )
+    );
 }

--- a/code-cast-project/app/(browse)/categories/javascript/page.js
+++ b/code-cast-project/app/(browse)/categories/javascript/page.js
@@ -1,7 +1,35 @@
+"use client"
+
+import { useState, useEffect } from 'react';
+
 export default function JavaScriptPage() {
+    const [streams, setStreams] = useState([]);
+
+    useEffect(() => {
+        async function fetchStreams() {
+            const response = await fetch('/api/fetchStreams?categoryName=JavaScript');
+            const data = await response.json();
+            setStreams(data);
+        }
+
+        fetchStreams();
+    }, []);
+
     return (
         <div>
-            JavaScript Page!
+            <h1 className="text-2xl font-semibold lg:text-4xl">JavaScript Streams</h1>
+            {streams.length > 0 ? (
+                streams.map((stream) => (
+                    <div key={stream.id}>
+                        <Link href={`/${stream.user.username}`}>
+                            <h2>{stream.name}</h2>
+                        </Link>
+                        {/* Display other stream details here */}
+                    </div>
+                ))
+            ) : (
+                <p>No current streams under the JavaScript category.</p>
+            )}
         </div>
-    )
+    );
 }

--- a/code-cast-project/app/(browse)/categories/python/page.js
+++ b/code-cast-project/app/(browse)/categories/python/page.js
@@ -1,7 +1,36 @@
+"use client"
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
 export default function PythonPage() {
+    const [streams, setStreams] = useState([]);
+
+    useEffect(() => {
+        async function fetchStreams() {
+            const response = await fetch('/api/fetchStreams?categoryName=Python');
+            const data = await response.json();
+            setStreams(data);
+        }
+
+        fetchStreams();
+    }, []);
+
     return (
         <div>
-            Python Page!
+            <h1 className="text-2xl font-semibold lg:text-4xl">Python Streams</h1>
+            {streams.length > 0 ? (
+                streams.map((stream) => (
+                    <div key={stream.id}>
+                        <Link href={`/${stream.user.username}`}>
+                            <h2>{stream.name}</h2>
+                        </Link>
+                        {/* Display other stream details here */}
+                    </div>
+                ))
+            ) : (
+                <p>No current streams under the Python category.</p>
+            )}
         </div>
-    )
+    );
 }

--- a/code-cast-project/app/(dashboard)/u/[username]/_components/sidebar/wrapper.js
+++ b/code-cast-project/app/(dashboard)/u/[username]/_components/sidebar/wrapper.js
@@ -7,7 +7,7 @@ function Wrapper({ children }) {
 
   return (
     <aside className={`fixed left-0 flex flex-col ${collapsed ? 'w-[70px]' : 'w-[280px]'} h-full border-r border-[#2D2E35] z-50 p-4`} style={{ backgroundColor: '#131F2F' }}>
-      <div className="space-y-6">
+      <div className="space-y-6 text-white">
         {children}
       </div>
     </aside>

--- a/code-cast-project/app/api/fetchStreams/route.js
+++ b/code-cast-project/app/api/fetchStreams/route.js
@@ -1,0 +1,41 @@
+// --> /api/fetchStreams/route.js
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function GET(req) {
+  try {
+    // get url
+    const url = new URL(req.url);
+    // search url
+    const searchParams = new URLSearchParams(url.search);
+    // search for categoryName
+    const categoryName = searchParams.get("categoryName");
+    // console for debugging
+    console.log(categoryName);
+    
+    // search db for live streams under category 
+    const liveStreams = await prisma.stream.findMany({
+      where: {
+        category: {
+          name: categoryName,
+        },
+        isLive: true,
+      },
+      include: {
+        user: true
+      }
+    });
+
+    return new Response(JSON.stringify(liveStreams), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ message: 'Error fetching live streams' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/code-cast-project/middleware.js
+++ b/code-cast-project/middleware.js
@@ -8,7 +8,8 @@ export default authMiddleware({
     "/",
     "/api/webhooks(.*)",
     "/search",
-    "/:username"
+    "/:username",
+    "/api/(.*)"
   ]
 });
  


### PR DESCRIPTION
## Overview

<!-- Denote the type of change being made. Select all that apply. -->
**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] UI change/fix (doesn't break core functionality that changes how app looks)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes  

<!-- Describe the change that is being made. -->
**Proposed Changes**  
*What is the current behavior?*

Category Page is empty and only displays text such as '(Java) page'. Users cannot search for live streams under a specific category. 

*What is the new behavior?*

New API route was added to fetch streams that are live under a specific category using query params. With this, I updated each Category page to use this fetch call to retrieve all streams under its own specific category. It will return an array of streams listed by their names in which the user can click on and get redirected to the actual livestream page where they can also join the room. Thus, users will now be able to search for live streams by category. 

**Screenshots**  

*Before*

![Before](https://github.com/ddthompson01/codecast/assets/101072878/dec43a9f-fb09-4666-9170-f35dfad157cd)


*After*

![After_Null](https://github.com/ddthompson01/codecast/assets/101072878/e9838400-34e7-4206-9cc9-013567c4d110)

![After_Stream](https://github.com/ddthompson01/codecast/assets/101072878/fafcc303-09a3-43fb-a4e5-b6ae6b307620)



