### PR TITLE
Added temporary chat component from livekit API

### DIFF
--- a/code-cast-project/components/livekitStream.js
+++ b/code-cast-project/components/livekitStream.js
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useUser } from "@clerk/nextjs";
-import { LiveKitRoom, GridLayout, ParticipantTile, RoomAudioRenderer, ControlBar, useTracks, LayoutContextProvider, ConnectionState } from '@livekit/components-react';
+import { LiveKitRoom, GridLayout, ParticipantTile, RoomAudioRenderer, ControlBar, useTracks, LayoutContextProvider, ConnectionState, Chat } from '@livekit/components-react';
 import { Track } from 'livekit-client';
 import '@livekit/components-styles';
 
@@ -39,19 +39,24 @@ export default function LiveKitStream({ room, style, isLive }) {
 
   return (
     <LayoutContextProvider>
+      <div className='flex'>
       <LiveKitRoom
         video={true}
         audio={true}
         token={token}
         serverUrl={process.env.NEXT_PUBLIC_LIVEKIT_WS_URL}
         data-lk-theme="default"
-        style={{ ...style }}
+        style={{ ...style, display: 'flex', flex: 1 }}
       >
-        <MyVideoConference />
-        <RoomAudioRenderer />
-        <ConnectionState />
-        <ControlBar/>
+        <div className="flex-grow">
+          <MyVideoConference />
+          <RoomAudioRenderer />
+          <ConnectionState />
+          <ControlBar />
+        </div>
+        <Chat className="flex-none w-1/4 min-w-[300px] max-w-[400px]" />
       </LiveKitRoom>
+      </div>
     </LayoutContextProvider>
   );
 }


### PR DESCRIPTION
## Overview

<!-- Denote the type of change being made. Select all that apply. -->
**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] UI change/fix (doesn't break core functionality that changes how app looks)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build related changes
- [ ] Documentation content changes  

<!-- Describe the change that is being made. -->
**Proposed Changes**  
*What is the current behavior?*

Dashboard/Casting page did not have a chat component and users were only able to talk to each other through stream. This would become an issue for those who may not have a working microphone on their device that they are using.

*What is the new behavior?*

LiveKit API has its own chat component that we can use within a LiveKitRoom component. So I added it to our dashboard page so users can also send a message and chat amongst each other. This also solves the issue for users that do not have a working microphone on their device. 

**Screenshots**  

*Before*

![Before](https://github.com/ddthompson01/codecast/assets/101072878/e4253e5a-8021-4341-9e52-2d3070bfdb46)

*After*

![After](https://github.com/ddthompson01/codecast/assets/101072878/37f9fc46-bae6-4e6f-86ac-cc063831d17d)


